### PR TITLE
Use Composer to install WP-CLI in tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,8 @@ cache:
 
 env:
   global:
-    - WP_CLI_BIN_DIR=/tmp/wp-cli-phar
+    - PATH="$TRAVIS_BUILD_DIR/vendor/bin:$PATH"
+    - WP_CLI_BIN_DIR="$TRAVIS_BUILD_DIR/vendor/bin"
 
 matrix:
   include:
@@ -32,9 +33,15 @@ matrix:
     - php: 5.3
       env: WP_VERSION=latest
 
-before_script:
+before_install:
   - phpenv config-rm xdebug.ini
-  - composer validate
+
+install:
+  - composer install
   - bash bin/install-package-tests.sh
 
-script: ./vendor/bin/behat --format progress --strict
+before_script:
+  - composer validate
+
+script:
+  - behat --format progress --strict

--- a/bin/install-package-tests.sh
+++ b/bin/install-package-tests.sh
@@ -2,39 +2,9 @@
 
 set -ex
 
-WP_CLI_BIN_DIR=${WP_CLI_BIN_DIR-/tmp/wp-cli-phar}
-
-PACKAGE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/../ && pwd )"
-
-download() {
-    if [ `which curl` ]; then
-        curl -s "$1" > "$2";
-    elif [ `which wget` ]; then
-        wget -nv -O "$2" "$1"
-    fi
-}
-
-install_wp_cli() {
-
-	# the Behat test suite will pick up the executable found in $WP_CLI_BIN_DIR
-	mkdir -p $WP_CLI_BIN_DIR
-	download https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli-nightly.phar $WP_CLI_BIN_DIR/wp
-	chmod +x $WP_CLI_BIN_DIR/wp
-
-}
-
-download_behat() {
-
-	cd $PACKAGE_DIR
-	composer require --dev behat/behat='~2.5'
-
-}
-
 install_db() {
 	mysql -e 'CREATE DATABASE IF NOT EXISTS wp_cli_test;' -uroot
 	mysql -e 'GRANT ALL PRIVILEGES ON wp_cli_test.* TO "wp_cli_test"@"localhost" IDENTIFIED BY "password1"' -uroot
 }
 
-install_wp_cli
-download_behat
 install_db

--- a/composer.json
+++ b/composer.json
@@ -21,11 +21,16 @@
         },
         "files": [ "eval-command.php" ]
     },
-    "require": {},
+    "require": {
+        "wp-cli/wp-cli": "dev-master"
+    },
     "require-dev": {
         "behat/behat": "~2.5"
     },
     "extra": {
+        "branch-alias": {
+            "dev-master": "1.0.x-dev"
+        },
         "commands": [
             "eval",
             "eval-file"

--- a/eval-command.php
+++ b/eval-command.php
@@ -5,7 +5,7 @@ if ( ! class_exists( 'WP_CLI' ) ) {
 }
 
 $autoload = dirname( __FILE__ ) . '/vendor/autoload.php';
-if ( file_exists( $autoload ) && ! class_exists( 'Eval_Command' ) ) {
+if ( file_exists( $autoload ) ) {
 	require_once $autoload;
 }
 

--- a/eval-command.php
+++ b/eval-command.php
@@ -5,7 +5,7 @@ if ( ! class_exists( 'WP_CLI' ) ) {
 }
 
 $autoload = dirname( __FILE__ ) . '/vendor/autoload.php';
-if ( file_exists( $autoload ) ) {
+if ( file_exists( $autoload ) && ! class_exists( 'Eval_Command' ) ) {
 	require_once $autoload;
 }
 


### PR DESCRIPTION
Doing so ensures tests run against local copy of command, instead of
Phar bundled version.

See https://github.com/wp-cli/wp-cli/issues/3850#issuecomment-288719442