### PR TITLE
Support eval-file from stdin (implementation for #19)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ to be explicitly globalized.
 **OPTIONS**
 
 	<file>
-		The path to the PHP file to execute.
+		The path to the PHP file to execute.  Use '-' to run code from stdin.
 
 	[<arg>...]
 		One or more arguments to pass to the file. They are placed in the $args variable.

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ to be explicitly globalized.
 **OPTIONS**
 
 	<file>
-		The path to the PHP file to execute.  Use '-' to run code from stdin.
+		The path to the PHP file to execute.  Use '-' to run code from STDIN.
 
 	[<arg>...]
 		One or more arguments to pass to the file. They are placed in the $args variable.

--- a/features/eval.feature
+++ b/features/eval.feature
@@ -57,3 +57,17 @@ Feature: Evaluating PHP code and files.
       """
       bool(false)
       """
+
+  Scenario: Eval stdin with args
+    Given an empty directory
+    And a script.php file:
+      """
+      <?php
+      WP_CLI::line( implode( ' ', $args ) );
+      """
+
+    When I run `cat script.php | wp eval-file - x y z --skip-wordpress`
+    Then STDOUT should contain:
+      """
+      x y z
+      """

--- a/src/EvalFile_Command.php
+++ b/src/EvalFile_Command.php
@@ -11,7 +11,7 @@ class EvalFile_Command extends WP_CLI_Command {
 	 * ## OPTIONS
 	 *
 	 * <file>
-	 * : The path to the PHP file to execute.
+	 * : The path to the PHP file to execute.  Use '-' to run code from stdin.
 	 *
 	 * [<arg>...]
 	 * : One or more arguments to pass to the file. They are placed in the $args variable.
@@ -28,7 +28,7 @@ class EvalFile_Command extends WP_CLI_Command {
 	public function __invoke( $args, $assoc_args ) {
 		$file = array_shift( $args );
 
-		if ( !file_exists( $file ) ) {
+		if ( "-" !== $file && !file_exists( $file ) ) {
 			WP_CLI::error( "'$file' does not exist." );
 		}
 
@@ -40,7 +40,11 @@ class EvalFile_Command extends WP_CLI_Command {
 	}
 
 	private static function _eval( $file, $args ) {
-		include( $file );
+		if ( "-" === $file ) {
+			eval( "?>" . file_get_contents("php://stdin"));
+		} else {
+			include( $file );
+		}
 	}
 }
 

--- a/src/EvalFile_Command.php
+++ b/src/EvalFile_Command.php
@@ -11,7 +11,7 @@ class EvalFile_Command extends WP_CLI_Command {
 	 * ## OPTIONS
 	 *
 	 * <file>
-	 * : The path to the PHP file to execute.  Use '-' to run code from stdin.
+	 * : The path to the PHP file to execute.  Use '-' to run code from STDIN.
 	 *
 	 * [<arg>...]
 	 * : One or more arguments to pass to the file. They are placed in the $args variable.
@@ -40,10 +40,10 @@ class EvalFile_Command extends WP_CLI_Command {
 	}
 
 	private static function _eval( $file, $args ) {
-		if ( "-" === $file ) {
-			eval( "?>" . file_get_contents("php://stdin"));
+		if ( '-' === $file ) {
+			eval( '?>' . file_get_contents('php://stdin') );
 		} else {
-			include( $file );
+			include $file;
 		}
 	}
 }

--- a/src/EvalFile_Command.php
+++ b/src/EvalFile_Command.php
@@ -28,7 +28,7 @@ class EvalFile_Command extends WP_CLI_Command {
 	public function __invoke( $args, $assoc_args ) {
 		$file = array_shift( $args );
 
-		if ( "-" !== $file && !file_exists( $file ) ) {
+		if ( '-' !== $file && !file_exists( $file ) ) {
 			WP_CLI::error( "'$file' does not exist." );
 		}
 


### PR DESCRIPTION
Per issue #19, this PR implements the ability to `wp eval-file` code from `php://stdin`, using `-` for consistency with other wp-cli commands that take input from stdin.