### PR TITLE
Handle #! in file inputs - idea #108

### DIFF
--- a/features/eval.feature
+++ b/features/eval.feature
@@ -21,6 +21,23 @@ Feature: Evaluating PHP code and files.
       foo bar
       """
 
+    Given a script.sh file:
+      """
+      #! /bin/bash
+      <?php
+      WP_CLI::line( implode( ' ', $args ) );
+      """
+
+    When I run `wp eval-file script.sh foo bar`
+    Then STDOUT should contain:
+      """
+      foo bar
+      """
+    But STDOUT should not contain:
+      """
+      #!
+      """
+
   Scenario: Eval without WordPress install
     Given an empty directory
 

--- a/src/EvalFile_Command.php
+++ b/src/EvalFile_Command.php
@@ -28,7 +28,7 @@ class EvalFile_Command extends WP_CLI_Command {
 	public function __invoke( $args, $assoc_args ) {
 		$file = array_shift( $args );
 
-		if ( '-' !== $file && !file_exists( $file ) ) {
+		if ( '-' !== $file && ! file_exists( $file ) ) {
 			WP_CLI::error( "'$file' does not exist." );
 		}
 
@@ -41,9 +41,14 @@ class EvalFile_Command extends WP_CLI_Command {
 
 	private static function _eval( $file, $args ) {
 		if ( '-' === $file ) {
-			eval( '?>' . file_get_contents('php://stdin') );
+			eval( '?>' . file_get_contents( 'php://stdin' ) );
 		} else {
-			include $file;
+			$file_contents = file_get_contents( $file );
+			if ( 0 === strpos( $file_contents, '#!' ) ) {
+				// Remove
+				$file_contents = preg_replace( '/^(#!.*)$/im', '', $file_contents );
+			}
+			eval( '?>' . $file_contents );
 		}
 	}
 }


### PR DESCRIPTION
Handle #! in file input to wp eval-file - [idea #108](https://github.com/wp-cli/ideas/issues/108)

Include file contents; detect #! and strip first line if found; eval result.