### PR TITLE
Fix handling of `__FILE__` and `__DIR__` constants in `eval()`'d code.

### DIFF
--- a/features/eval.feature
+++ b/features/eval.feature
@@ -88,3 +88,73 @@ Feature: Evaluating PHP code and files.
       """
       x y z
       """
+
+  Scenario: Eval-file will use the correct __FILE__ constant value
+    Given an empty directory
+    And a script.php file:
+      """
+      <?php
+      echo __FILE__;
+      """
+
+    When I run `wp eval-file script.php --skip-wordpress`
+    Then STDOUT should contain:
+      """
+      /script.php
+      """
+    And STDOUT should not contain:
+      """
+      eval()'d code
+      """
+
+  Scenario: Eval-file will not replace __FILE__ when quoted
+    Given an empty directory
+    And a script.php file:
+      """
+      <?php
+      echo '__FILE__';
+      echo "__FILE__";
+      echo '"__FILE__"';
+      echo "'__FILE__'";
+
+      echo ' foo __FILE__ bar ';
+      echo " foo __FILE__ bar ";
+      echo '" foo __FILE__ bar "';
+      echo "' foo __FILE__ bar '";
+      """
+
+    When I run `wp eval-file script.php --skip-wordpress`
+    Then STDOUT should contain:
+      """
+      __FILE__
+      """
+    And STDOUT should not contain:
+      """
+      /script.php
+      """
+    And STDOUT should not contain:
+      """
+      eval()'d code
+      """
+
+  Scenario: Eval-file can handle both quoted and unquoted __FILE__ correctly
+    Given an empty directory
+    And a script.php file:
+      """
+      <?php
+      echo ' __FILE__ => ' . __FILE__;
+      """
+
+    When I run `wp eval-file script.php --skip-wordpress`
+    Then STDOUT should contain:
+      """
+      __FILE__ =>
+      """
+    And STDOUT should contain:
+      """
+      /script.php
+      """
+    And STDOUT should not contain:
+      """
+      eval()'d code
+      """

--- a/features/eval.feature
+++ b/features/eval.feature
@@ -158,3 +158,28 @@ Feature: Evaluating PHP code and files.
       """
       eval()'d code
       """
+
+  Scenario: Eval-file will use the correct __FILE__ constant value
+    Given an empty directory
+    And a script.php file:
+      """
+      <?php
+      echo __FILE__ . PHP_EOL;
+      """
+    And a dir_script.php file:
+      """
+      <?php
+      echo __DIR__ . '/script.php' . PHP_EOL;
+      """
+    And I run `wp eval-file script.php --skip-wordpress`
+    And save STDOUT as {FILE_OUTPUT}
+
+    When I run `wp eval-file dir_script.php --skip-wordpress`
+    Then STDOUT should be:
+      """
+      {FILE_OUTPUT}
+      """
+    And STDOUT should not contain:
+      """
+      eval()'d code
+      """

--- a/src/EvalFile_Command.php
+++ b/src/EvalFile_Command.php
@@ -51,16 +51,21 @@ class EvalFile_Command extends WP_CLI_Command {
 			}
 
 			$file = realpath( $file );
+			$dir  = dirname( $file );
 
-			// Replace __FILE__ constant with value of $file.
-			// We try to be smart and only replace the constant when it is not within quotes.
+			// Replace __FILE__ and __DIR__ constants with value of $file or $dir.
+			// We try to be smart and only replace the constants when they are not within quotes.
 			// Regular expressions being stateless, this is probably not 100% correct for edge cases.
-			// See https://regex101.com/r/9hXp5d/1
+			// See https://regex101.com/r/9hXp5d/2/
 			$file_contents = preg_replace_callback(
-				'/(?>\'[^\']*?\')|(?>"[^"]*?")|(?<target>__FILE__)/m',
-				function ( $matches ) use ( $file ) {
-					if ( array_key_exists( 'target', $matches ) ) {
+				'/(?>\'[^\']*?\')|(?>"[^"]*?")|(?<file>__FILE__)|(?<dir>__DIR__)/m',
+				function ( $matches ) use ( $file, $dir ) {
+					if ( ! empty( $matches['file'] ) ) {
 						return "'{$file}'";
+					}
+
+					if ( ! empty( $matches['dir'] ) ) {
+						return "'{$dir}'";
 					}
 
 					return $matches[0];


### PR DESCRIPTION
Using a regular expression to match all `__FILE__` and `__DIR__` constants that are not wrapped in quotes ( see https://regex101.com/r/9hXp5d/2/ ), we replace these with single-quoted strings that are the `realpath()` of the current file, or the `dirname()` of that file, respectively.

Fixes #37