### PR TITLE
Implement CS checking based on the `WP_CLI_CS` ruleset

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -6,6 +6,8 @@
 .travis.yml
 behat.yml
 circle.yml
+phpcs.xml.dist
+phpunit.xml.dist
 bin/
 features/
 utils/

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ vendor/
 *.tar.gz
 composer.lock
 *.log
+phpunit.xml
+phpcs.xml
+.phpcs.xml

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "wp-cli/wp-cli": "^2"
     },
     "require-dev": {
-        "wp-cli/wp-cli-tests": "^2.0.7"
+        "wp-cli/wp-cli-tests": "^2.1"
     },
     "config": {
         "process-timeout": 7200,

--- a/eval-command.php
+++ b/eval-command.php
@@ -4,9 +4,9 @@ if ( ! class_exists( 'WP_CLI' ) ) {
 	return;
 }
 
-$autoload = dirname( __FILE__ ) . '/vendor/autoload.php';
-if ( file_exists( $autoload ) ) {
-	require_once $autoload;
+$wpcli_eval_autoloader = dirname( __FILE__ ) . '/vendor/autoload.php';
+if ( file_exists( $wpcli_eval_autoloader ) ) {
+	require_once $wpcli_eval_autoloader;
 }
 
 WP_CLI::add_command( 'eval', 'Eval_Command' );

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,62 @@
+<?xml version="1.0"?>
+<ruleset name="WP-CLI-eval">
+	<description>Custom ruleset for WP-CLI eval-command</description>
+
+	<!--
+	#############################################################################
+	COMMAND LINE ARGUMENTS
+	For help understanding this file: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml
+	For help using PHPCS: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage
+	#############################################################################
+	-->
+
+	<!-- What to scan. -->
+	<file>.</file>
+
+	<!-- Show progress. -->
+	<arg value="p"/>
+
+	<!-- Strip the filepaths down to the relevant bit. -->
+	<arg name="basepath" value="./"/>
+
+	<!-- Check up to 8 files simultaneously. -->
+	<arg name="parallel" value="8"/>
+
+	<!--
+	#############################################################################
+	USE THE WP_CLI_CS RULESET
+	#############################################################################
+	-->
+
+	<rule ref="WP_CLI_CS">
+		<!-- Running code through eval is the point of this command. -->
+		<exclude name="Squiz.PHP.Eval.Discouraged"/>
+	</rule>
+
+	<!--
+	#############################################################################
+	PROJECT SPECIFIC CONFIGURATION FOR SNIFFS
+	#############################################################################
+	-->
+
+	<!-- For help understanding the `testVersion` configuration setting:
+		 https://github.com/PHPCompatibility/PHPCompatibility#sniffing-your-code-for-compatibility-with-specific-php-versions -->
+	<config name="testVersion" value="5.4-"/>
+
+	<!-- Verify that everything in the global namespace is either namespaced or prefixed.
+		 See: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#naming-conventions-prefix-everything-in-the-global-namespace -->
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
+		<properties>
+			<property name="prefixes" type="array">
+				<element value="WP_CLI\Eval"/><!-- Namespaces. -->
+				<element value="wpcli_eval"/><!-- Global variables and such. -->
+			</property>
+		</properties>
+	</rule>
+
+	<!-- Exclude existing classes from the prefix rule as it would break BC to prefix them now. -->
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound">
+		<exclude-pattern>*/src/Eval(File)?_Command\.php$</exclude-pattern>
+	</rule>
+
+</ruleset>

--- a/src/EvalFile_Command.php
+++ b/src/EvalFile_Command.php
@@ -36,10 +36,10 @@ class EvalFile_Command extends WP_CLI_Command {
 			WP_CLI::get_runner()->load_wordpress();
 		}
 
-		self::_eval( $file, $args );
+		self::execute_eval( $file, $args );
 	}
 
-	private static function _eval( $file, $args ) {
+	private static function execute_eval( $file, $args ) {
 		if ( '-' === $file ) {
 			eval( '?>' . file_get_contents( 'php://stdin' ) );
 		} else {


### PR DESCRIPTION
This adds a PHPCS ruleset using the new `WP_CLI_CS` standard and fixes tow minor infractions.

Please see the individual commits for more detail.

Fixes #39

Related to https://github.com/wp-cli/wp-cli/issues/5179