### PR TITLE
Improve `__FILE__`/`__DIR__` regex pattern

### DIFF
--- a/src/EvalFile_Command.php
+++ b/src/EvalFile_Command.php
@@ -57,15 +57,16 @@ class EvalFile_Command extends WP_CLI_Command {
 			WP_CLI::get_runner()->load_wordpress();
 		}
 
-		self::execute_eval( $file );
+		self::execute_eval( $file, $args );
 	}
 
 	/**
 	 * Evaluate a provided file.
 	 *
 	 * @param string $file Filepath to execute, or - for STDIN.
+	 * @param mixed  $args One or more arguments to pass to the file.
 	 */
-	private static function execute_eval( $file ) {
+	private static function execute_eval( $file, $args ) {
 		if ( '-' === $file ) {
 			eval( '?>' . file_get_contents( 'php://stdin' ) );
 		} else {

--- a/src/EvalFile_Command.php
+++ b/src/EvalFile_Command.php
@@ -9,7 +9,7 @@ class EvalFile_Command extends WP_CLI_Command {
 	 *
 	 * @var string
 	 */
-	const SHE_BANG_PATTERN = '/^(#!.*)$/m';
+	const SHEBANG_PATTERN = '/^(#!.*)$/m';
 
 	/**
 	 * Regular expression pattern to match __FILE__ and __DIR__ constants.
@@ -73,7 +73,7 @@ class EvalFile_Command extends WP_CLI_Command {
 
 			// Check for and remove she-bang.
 			if ( 0 === strncmp( $file_contents, '#!', 2 ) ) {
-				$file_contents = preg_replace( static::SHE_BANG_PATTERN, '', $file_contents );
+				$file_contents = preg_replace( static::SHEBANG_PATTERN, '', $file_contents );
 			}
 
 			$file = realpath( $file );

--- a/src/EvalFile_Command.php
+++ b/src/EvalFile_Command.php
@@ -1,6 +1,27 @@
 <?php
 
+use WP_CLI\Utils;
+
 class EvalFile_Command extends WP_CLI_Command {
+
+	/**
+	 * Regular expression pattern to match the shell shebang.
+	 *
+	 * @var string
+	 */
+	const SHE_BANG_PATTERN = '/^(#!.*)$/m';
+
+	/**
+	 * Regular expression pattern to match __FILE__ and __DIR__ constants.
+	 *
+	 * We try to be smart and only replace the constants when they are not within quotes.
+	 * Regular expressions being stateless, this is probably not 100% correct for edge cases.
+	 *
+	 * @see https://regex101.com/r/9hXp5d/4/
+	 *
+	 * @var string
+	 */
+	const FILE_DIR_PATTERN = '/(?>\'[^\']*?\')|(?>"[^"]*?")|(?<file>\b__FILE__\b)|(?<dir>\b__DIR__\b)/m';
 
 	/**
 	 * Loads and executes a PHP file.
@@ -32,34 +53,36 @@ class EvalFile_Command extends WP_CLI_Command {
 			WP_CLI::error( "'$file' does not exist." );
 		}
 
-		if ( null === \WP_CLI\Utils\get_flag_value( $assoc_args, 'skip-wordpress' ) ) {
+		if ( null === Utils\get_flag_value( $assoc_args, 'skip-wordpress' ) ) {
 			WP_CLI::get_runner()->load_wordpress();
 		}
 
-		self::execute_eval( $file, $args );
+		self::execute_eval( $file );
 	}
 
-	private static function execute_eval( $file, $args ) {
+	/**
+	 * Evaluate a provided file.
+	 *
+	 * @param string $file Filepath to execute, or - for STDIN.
+	 */
+	private static function execute_eval( $file ) {
 		if ( '-' === $file ) {
 			eval( '?>' . file_get_contents( 'php://stdin' ) );
 		} else {
 			$file_contents = file_get_contents( $file );
 
 			// Check for and remove she-bang.
-			if ( 0 === strpos( $file_contents, '#!' ) ) {
-				$file_contents = preg_replace( '/^(#!.*)$/im', '', $file_contents );
+			if ( 0 === strncmp( $file_contents, '#!', 2 ) ) {
+				$file_contents = preg_replace( static::SHE_BANG_PATTERN, '', $file_contents );
 			}
 
 			$file = realpath( $file );
 			$dir  = dirname( $file );
 
 			// Replace __FILE__ and __DIR__ constants with value of $file or $dir.
-			// We try to be smart and only replace the constants when they are not within quotes.
-			// Regular expressions being stateless, this is probably not 100% correct for edge cases.
-			// See https://regex101.com/r/9hXp5d/2/
 			$file_contents = preg_replace_callback(
-				'/(?>\'[^\']*?\')|(?>"[^"]*?")|(?<file>__FILE__)|(?<dir>__DIR__)/m',
-				function ( $matches ) use ( $file, $dir ) {
+				static::FILE_DIR_PATTERN,
+				static function ( $matches ) use ( $file, $dir ) {
 					if ( ! empty( $matches['file'] ) ) {
 						return "'{$file}'";
 					}

--- a/src/EvalFile_Command.php
+++ b/src/EvalFile_Command.php
@@ -64,7 +64,7 @@ class EvalFile_Command extends WP_CLI_Command {
 	 * Evaluate a provided file.
 	 *
 	 * @param string $file Filepath to execute, or - for STDIN.
-	 * @param mixed  $args One or more arguments to pass to the file.
+	 * @param mixed  $args Array of positional arguments to pass to the file.
 	 */
 	private static function execute_eval( $file, $args ) {
 		if ( '-' === $file ) {


### PR DESCRIPTION
The previous pattern would erroneously match a string like `SOMETHING__FILE__`.

See https://regex101.com/r/9hXp5d/4/ for the new pattern.