### PR TITLE
Minor documentation tweaks to `wp eval-file`

### DIFF
--- a/src/EvalFile_Command.php
+++ b/src/EvalFile_Command.php
@@ -35,7 +35,7 @@ class EvalFile_Command extends WP_CLI_Command {
 	 *
 	 * ## EXAMPLES
 	 *
-	 *     # Execute file my-code.php and pass value1 and value2 arguments. 
+	 *     # Execute file my-code.php and pass value1 and value2 arguments.
 	 *     # Access arguments in $args array ($args[0] = value1, $args[1] = value2).
 	 *     $ wp eval-file my-code.php value1 value2
 	 */

--- a/src/EvalFile_Command.php
+++ b/src/EvalFile_Command.php
@@ -38,8 +38,6 @@ class EvalFile_Command extends WP_CLI_Command {
 	 *     # Execute file my-code.php and pass value1 and value2 arguments. 
 	 *     # Access arguments in $args array ($args[0] = value1, $args[1] = value2).
 	 *     $ wp eval-file my-code.php value1 value2
-	 *
-	 * @package wp-cli
 	 */
 	public function __invoke( $args, $assoc_args ) {
 		$file = array_shift( $args );

--- a/src/EvalFile_Command.php
+++ b/src/EvalFile_Command.php
@@ -23,7 +23,7 @@ class EvalFile_Command extends WP_CLI_Command {
 	 * : The path to the PHP file to execute.  Use '-' to run code from STDIN.
 	 *
 	 * [<arg>...]
-	 * : One or more arguments to pass to the file. They are placed in the $args variable.
+	 * : One or more positional arguments to pass to the file. They are placed in the $args variable.
 	 *
 	 * [--skip-wordpress]
 	 * : Load and execute file without loading WordPress.
@@ -35,7 +35,11 @@ class EvalFile_Command extends WP_CLI_Command {
 	 *
 	 * ## EXAMPLES
 	 *
-	 *     wp eval-file my-code.php value1 value2
+	 *     # Execute file my-code.php and pass value1 and value2 arguments. 
+	 *     # Access arguments in $args array ($args[0] = value1, $args[1] = value2).
+	 *     $ wp eval-file my-code.php value1 value2
+	 *
+	 * @package wp-cli
 	 */
 	public function __invoke( $args, $assoc_args ) {
 		$file = array_shift( $args );


### PR DESCRIPTION
1. Noting that arguments are positional. The example is not visible in the docs, so I had to do a bit of guesswork here.
2. Example is not visible in the docs. Hopefully, it'll be resolved by fixed formatting.

<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review: https://make.wordpress.org/cli/handbook/code-review/
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->
