### PR TITLE
Make $args available as global

### DIFF
--- a/src/EvalFile_Command.php
+++ b/src/EvalFile_Command.php
@@ -68,6 +68,7 @@ class EvalFile_Command extends WP_CLI_Command {
 	 */
 	private static function execute_eval( $file, $positional_args, $use_include ) {
 		global $args;
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
 		$args = $positional_args;
 		unset( $positional_args );
 


### PR DESCRIPTION
Fix: https://github.com/wp-cli/eval-command/issues/80

`unset` to not make $positional_args available in the included file